### PR TITLE
Fix repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "authors": [
     "Justin Murray <justin@murrayju.com>"
   ],
-  "repository": "https://github.com/murrayju/build-strap",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/murrayju/build-strap"
+  },
   "main": "dist/build-tools-node.js",
   "engines": {
     "node": ">=7",


### PR DESCRIPTION
Per the [NPM docs](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository), if specifying a full URL, then need to pass it as an object to `repository` field. This should get the URL to show up properly on https://npmjs.com/package/build-strap. Alternative would be to do `"repository": "github:murrayju/build-strap", but I find that syntax confusing.