### PR TITLE
Add macos util function to check for rosetta installation

### DIFF
--- a/src/macos.ts
+++ b/src/macos.ts
@@ -45,3 +45,17 @@ export const ensureXcodeCmdInstalled = async (ignoreNonMac = true) => {
     });
   }
 };
+
+export const ensureRosettaInstalled = async (ignoreNonMac = true) => {
+  if (!isMac()) {
+    if (!ignoreNonMac) {
+      throw new Error('Cannot install Rosetta on non-macOS');
+    }
+    return;
+  }
+
+  if (!(await fs.pathExists('/usr/libexec/rosetta'))) {
+    buildLog('Installing Rosetta...');
+    await spawn('softwareupdate', ['--install-rosetta', '--agree-to-license']);
+  }
+};


### PR DESCRIPTION
PR adds a macos util function that ensures that [Rosetta](https://en.wikipedia.org/wiki/Rosetta_(software)) is installed, and if not, it runs the installer for it.

I based the solution for detecting rosetta on https://apple.stackexchange.com/a/427996, with the expectation that `/usr/libexec/rosetta` will not exist on a new computer (vs some of the other locations), though it's hard for me to test.

An alternative would be to to test for process names (see https://apple.stackexchange.com/a/435190), though not sure it's better, and would be a bit less documenting due to the usage of internal "OAH" name.