### PR TITLE
Ignore output from sourcing shellEnvFile in readShellEnvVar

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -105,7 +105,12 @@ export const readShellEnvVar = async (
     return (
       await spawn(
         shell,
-        ['-c', `${refreshEnv ? `source ${envFile} && ` : ''}printenv ${name}`],
+        [
+          '-c',
+          `${
+            refreshEnv ? `source ${envFile} > /dev/null 2>&1  && ` : ''
+          }printenv ${name}`,
+        ],
         {
           captureOutput: true,
           env: {


### PR DESCRIPTION
PR fixes a bug where if the `sourceEnvFile` had something that caused an output (e.g. `echo "foo"`), then it would show up in the returned value from `readShellEnvVar`. Now, both stdout and stderr will be redirected into `/dev/null` so that it won't impact the output from `printenv`.

A simple way to cause the issue is to do:
```
echo "echo 'foo'\n>&2 echo 'error'" >> ~/.zshrc
```

and then within node (`node --loader ts-node/esm`):
```
> import('./build/src/env.js').then((module) => {
  readShellEnvVar = module.readShellEnvVar;
  });
> await readShellEnvVar('USER');
```

where before this change the response was `foo\nerror\nmpeveler` and with this change it was `mpeveler` as expected.